### PR TITLE
Adding get_set_life_time method.

### DIFF
--- a/volatile_dictionary/volatile_dictionary.py
+++ b/volatile_dictionary/volatile_dictionary.py
@@ -39,3 +39,12 @@ class VolatileDictionary(dict):
     def _evaporate(self, key):
         super().__delitem__(key)
         del self._evaporation_jobs[key]
+
+    def get_set_life_time(self, key):
+        if key not in self._evaporation_jobs:
+            raise TypeError('This set is not volatile')
+
+        job_id = self._evaporation_jobs[key]
+        job = self._scheduler.get_job(job_id)
+        job_date = job.trigger.run_date
+        return (job_date - datetime.now(job_date.tzinfo)).total_seconds()


### PR DESCRIPTION
Adding the get_setl_life_time method in order to return how much seconds the set will take to expire. 
The method raises TypeError if the set is not volatile.